### PR TITLE
简化 msg_txt_cn 宏定义的实现方法, 移除多余代码

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3144,12 +3144,6 @@ void char_do_final_msg(void){
 	_do_final_msg(CHAR_MAX_MSG,msg_table);
 }
 
-#ifdef rAthenaCN_Message_Conf
-const char* char_msg_txt_cn(int msg_number) {
-	return _msg_txt(msg_number + ALL_EXTEND_FIRST_MSG, CHAR_MAX_MSG, msg_table);
-}
-#endif // rAthenaCN_Message_Conf
-
 
 void do_final(void)
 {

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -332,15 +332,13 @@ void char_set_session_flag_(int account_id, int val, bool set);
 
 #define msg_config_read(cfgName) char_msg_config_read(cfgName)
 #define msg_txt(msg_number) char_msg_txt(msg_number)
+#ifdef rAthenaCN_Message_Conf
+#define msg_txt_cn(msg_number) char_msg_txt(msg_number + ALL_EXTEND_FIRST_MSG)
+#endif // rAthenaCN_Message_Conf
 #define do_final_msg() char_do_final_msg()
 int char_msg_config_read(const char *cfgName);
 const char* char_msg_txt(int msg_number);
 void char_do_final_msg(void);
 bool char_config_read(const char* cfgName, bool normal);
-
-#ifdef rAthenaCN_Message_Conf
-#define msg_txt_cn(msg_number) char_msg_txt_cn(msg_number)
-const char* char_msg_txt_cn(int msg_number);
-#endif // rAthenaCN_Message_Conf
 
 #endif /* CHAR_HPP */

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -334,6 +334,8 @@ void char_set_session_flag_(int account_id, int val, bool set);
 #define msg_txt(msg_number) char_msg_txt(msg_number)
 #ifdef rAthenaCN_Message_Conf
 #define msg_txt_cn(msg_number) char_msg_txt(msg_number + ALL_EXTEND_FIRST_MSG)
+#else
+#define msg_txt_cn(msg_number) disabled_msg_txt(msg_number + ALL_EXTEND_FIRST_MSG)
 #endif // rAthenaCN_Message_Conf
 #define do_final_msg() char_do_final_msg()
 int char_msg_config_read(const char *cfgName);

--- a/src/common/msg_conf.cpp
+++ b/src/common/msg_conf.cpp
@@ -11,6 +11,15 @@
 #include "showmsg.hpp"
 #include "strlib.hpp"
 
+#ifndef rAthenaCN_Message_Conf
+// 当禁用 rAthenaCN_Message_Conf 的时候
+// 能够显示出对应的警告信息出来, 告诉用户原因同时避免编译错误 [Sola丶小克]
+const char* disabled_msg_txt(int msg_number) {
+	ShowWarning("Program will return 'unknow' for msg_number : %d calling by 'msg_txt_cn' function, because the message conf improvements has been disabled.\n", msg_number);
+	return "unknow";
+}
+#endif // rAthenaCN_Message_Conf
+
 /*
  * Return the message string of the specified number by [Yor]
  * (read in table msg_table, with specified lenght table in size)
@@ -62,8 +71,19 @@ int _msg_config_read(const char* cfgName,int size, char ** msg_table)
 				safestrncpy(msg_table[msg_number], w2, len);
 				msg_count++;
 			}
+#ifdef rAthenaCN_Message_Conf
 			else
 				ShowWarning("Invalid message ID '%s' at line %d from '%s' file.\n",w1,line_num,cfgName);
+#else
+			// 若没有启用 rAthenaCN_Message_Conf 宏定义的话
+			// 为了避免持续集成判定失败, 这里针对 >= ALL_EXTEND_FIRST_MSG 的 msg_number 降低报错等级
+			else {
+				if (msg_number < ALL_EXTEND_FIRST_MSG)
+					ShowWarning("Invalid message ID '%s' at line %d from '%s' file.\n", w1, line_num, cfgName);
+				else
+					ShowInfo("Invalid message ID '%s' at line %d from '%s' file.\n", w1, line_num, cfgName);
+			}
+#endif // rAthenaCN_Message_Conf
 		}
 	}
 

--- a/src/common/msg_conf.hpp
+++ b/src/common/msg_conf.hpp
@@ -26,7 +26,7 @@ enum lang_types {
 	#define LANG_ENABLE 0x000
 #endif
 
-#ifdef rAthenaCN_Message_Conf
+// =================================================================================
 // 追加一部分消息区间给 rAthenaCN 扩展使用 [Sola丶小克]
 //
 // 截止 2018年11月20日 rAthena 默认的宏定义默认值如下:
@@ -40,9 +40,14 @@ enum lang_types {
 // 启用此机制后, 会在 login.hpp \ char.hpp \ map.hpp 提供一个 msg_txt_cn 的宏定义函数
 // 通过 msg_txt_cn 传入的 msg_number 会自动加 ALL_EXTEND_FIRST_MSG 作为最终的 msg_number
 // 并从 conf/msg_conf 中读取对应的消息, 作为返回值.
+// =================================================================================
 #define ALL_EXTEND_MSG 3000
 #define ALL_EXTEND_FIRST_MSG 2000
+
+#ifndef rAthenaCN_Message_Conf
+const char* disabled_msg_txt(int msg_number);
 #endif // rAthenaCN_Message_Conf
+// =================================================================================
 
 //read msg in table
 const char* _msg_txt(int msg_number,int size, char ** msg_table);

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -533,12 +533,6 @@ void login_do_final_msg(void){
 	_do_final_msg(LOGIN_MAX_MSG,msg_table);
 }
 
-#ifdef rAthenaCN_Message_Conf
-const char* login_msg_txt_cn(int msg_number) {
-	return _msg_txt(msg_number + ALL_EXTEND_FIRST_MSG, LOGIN_MAX_MSG, msg_table);
-}
-#endif // rAthenaCN_Message_Conf
-
 
 /// Set and read Configurations
 

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -129,17 +129,14 @@ extern struct Login_Config login_config;
 
 #define msg_config_read(cfgName) login_msg_config_read(cfgName)
 #define msg_txt(msg_number) login_msg_txt(msg_number)
+#ifdef rAthenaCN_Message_Conf
+#define msg_txt_cn(msg_number) login_msg_txt(msg_number + ALL_EXTEND_FIRST_MSG)
+#endif // rAthenaCN_Message_Conf
 #define do_final_msg() login_do_final_msg()
 int login_msg_config_read(char *cfgName);
 const char* login_msg_txt(int msg_number);
 void login_do_final_msg(void);
 bool login_config_read(const char* cfgName, bool normal);
-
-#ifdef rAthenaCN_Message_Conf
-#define msg_txt_cn(msg_number) login_msg_txt_cn(msg_number)
-const char* login_msg_txt_cn(int msg_number);
-#endif // rAthenaCN_Message_Conf
-
 /// Online User Database [Wizputer]
 struct online_login_data {
 	uint32 account_id;

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -131,6 +131,8 @@ extern struct Login_Config login_config;
 #define msg_txt(msg_number) login_msg_txt(msg_number)
 #ifdef rAthenaCN_Message_Conf
 #define msg_txt_cn(msg_number) login_msg_txt(msg_number + ALL_EXTEND_FIRST_MSG)
+#else
+#define msg_txt_cn(msg_number) disabled_msg_txt(msg_number + ALL_EXTEND_FIRST_MSG)
 #endif // rAthenaCN_Message_Conf
 #define do_final_msg() login_do_final_msg()
 int login_msg_config_read(char *cfgName);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -5288,25 +5288,6 @@ const char* map_msg_txt(struct map_session_data *sd, int msg_number){
 	return "??";
 }
 
-#ifdef rAthenaCN_Message_Conf
-const char* map_msg_txt_cn(struct map_session_data *sd, int msg_number) {
-	struct msg_data *mdb;
-	uint8 lang = 0; //default
-	if (sd && sd->langtype) lang = sd->langtype;
-
-	if ((mdb = map_lang2msgdb(lang)) != NULL) {
-		const char *tmp = _msg_txt(msg_number + ALL_EXTEND_FIRST_MSG, MAP_MAX_MSG, mdb->msg);
-		if (strcmp(tmp, "??")) //to verify result
-			return tmp;
-		ShowDebug("Message #%d not found for langtype %d.\n", msg_number + ALL_EXTEND_FIRST_MSG, lang);
-	}
-	ShowDebug("Selected langtype %d not loaded, trying fallback...\n", lang);
-	if (lang != 0 && (mdb = map_lang2msgdb(0)) != NULL) //fallback
-		return _msg_txt(msg_number + ALL_EXTEND_FIRST_MSG, MAP_MAX_MSG, mdb->msg);
-	return "??";
-}
-#endif // rAthenaCN_Message_Conf
-
 /// Called when a terminate signal is received.
 void do_shutdown(void)
 {

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -36,16 +36,14 @@ enum E_MAPSERVER_ST {
 struct map_data *map_getmapdata(int16 m);
 #define msg_config_read(cfgName,isnew) map_msg_config_read(cfgName,isnew)
 #define msg_txt(sd,msg_number) map_msg_txt(sd,msg_number)
+#ifdef rAthenaCN_Message_Conf
+#define msg_txt_cn(sd,msg_number) map_msg_txt(sd,msg_number + ALL_EXTEND_FIRST_MSG)
+#endif // rAthenaCN_Message_Conf
 #define do_final_msg() map_do_final_msg()
 int map_msg_config_read(const char *cfgName,int lang);
 const char* map_msg_txt(struct map_session_data *sd,int msg_number);
 void map_do_final_msg(void);
 void map_msg_reload(void);
-
-#ifdef rAthenaCN_Message_Conf
-#define msg_txt_cn(sd,msg_number) map_msg_txt_cn(sd,msg_number)
-const char* map_msg_txt_cn(struct map_session_data *sd, int msg_number);
-#endif // rAthenaCN_Message_Conf
 
 #define MAX_NPC_PER_MAP 512
 #define AREA_SIZE battle_config.area_size

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -38,6 +38,8 @@ struct map_data *map_getmapdata(int16 m);
 #define msg_txt(sd,msg_number) map_msg_txt(sd,msg_number)
 #ifdef rAthenaCN_Message_Conf
 #define msg_txt_cn(sd,msg_number) map_msg_txt(sd,msg_number + ALL_EXTEND_FIRST_MSG)
+#else
+#define msg_txt_cn(sd,msg_number) disabled_msg_txt(msg_number + ALL_EXTEND_FIRST_MSG)
 #endif // rAthenaCN_Message_Conf
 #define do_final_msg() map_do_final_msg()
 int map_msg_config_read(const char *cfgName,int lang);


### PR DESCRIPTION
以前的实现方式有点冗余，改进一下
此外对于关闭 rAthenaCN_Message_Conf 之后的程序行为也进行调整，避免编译失败
